### PR TITLE
Initial CIDOC CRM toolkit implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+.eggs/
+*.egg-info/
+.pytest_cache/
+.dist-info/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# CIDOC CRM Toolkit
+
+A modern, Pydantic v2-based toolkit for modeling [CIDOC CRM v7.1.3](https://cidoc-crm.org/html/cidoc_crm_v7.1.3.html) entities and relationships.
+
+## Features
+
+- **Typed models** built with Pydantic representing core CIDOC CRM entities and properties.
+- **Graph storage** with an in-memory NetworkX backend and a repository abstraction for extensibility.
+- **FastAPI JSON API** for CRUD access to entities and their relationships.
+- **Typer-powered CLI** following the Linux philosophy of composable commands for importing, exporting, and inspecting data.
+- **Automated tests** covering the repository layer and HTTP API.
+
+## Getting Started
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[test]
+```
+
+### Run the API
+
+```bash
+uvicorn cidoc_crm_toolkit.api:app --reload
+```
+
+### Use the CLI
+
+```bash
+python -m cidoc_crm_toolkit.cli --help
+```
+
+## Tests
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cidoc-crm-toolkit"
+version = "0.1.0"
+description = "Modern, Pydantic-based CIDOC CRM modeling toolkit with graph storage and JSON API"
+authors = [{ name = "CIDOC CRM Toolkit", email = "developers@example.com" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.0",
+    "fastapi>=0.110",
+    "uvicorn>=0.23",
+    "typer>=0.9",
+    "networkx>=3.1"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4",
+    "pytest-asyncio>=0.21",
+    "httpx>=0.27"
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+asyncio_mode = "auto"
+pythonpath = ["src"]

--- a/src/cidoc_crm_toolkit/__init__.py
+++ b/src/cidoc_crm_toolkit/__init__.py
@@ -1,0 +1,18 @@
+"""CIDOC CRM Toolkit package."""
+
+from .enums import CRMEntityType, CRMPropertyType
+from .models import CRMEntity, CRMIdentifier, CRMRelationship, TimeSpan
+from .repository import GraphRepository, InMemoryGraphRepository
+
+__all__ = [
+    "CRMEntity",
+    "CRMEntityType",
+    "CRMIdentifier",
+    "CRMPropertyType",
+    "CRMRelationship",
+    "GraphRepository",
+    "InMemoryGraphRepository",
+    "TimeSpan",
+]
+
+__version__ = "0.1.0"

--- a/src/cidoc_crm_toolkit/api.py
+++ b/src/cidoc_crm_toolkit/api.py
@@ -1,0 +1,163 @@
+"""FastAPI application exposing CIDOC CRM graph functionality."""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, status
+
+from .enums import CRMEntityType, CRMPropertyType
+from .exceptions import (
+    EntityAlreadyExists,
+    EntityNotFound,
+    RelationshipAlreadyExists,
+    RelationshipNotFound,
+)
+from .models import CRMEntity, CRMRelationship
+from .repository import GraphRepository, InMemoryGraphRepository
+
+app = FastAPI(
+    title="CIDOC CRM Toolkit API",
+    description="JSON API for working with CIDOC CRM entities and relationships",
+    version="0.1.0",
+)
+
+_repository = InMemoryGraphRepository()
+
+
+def get_repository() -> GraphRepository:
+    """Dependency returning the singleton in-memory repository."""
+
+    return _repository
+
+
+@app.get("/health", tags=["meta"])
+def health() -> dict[str, str]:
+    """Return basic health information."""
+
+    return {"status": "ok"}
+
+
+@app.post("/entities", response_model=CRMEntity, status_code=status.HTTP_201_CREATED, tags=["entities"])
+def create_entity(
+    entity: CRMEntity,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> CRMEntity:
+    try:
+        return repository.create_entity(entity)
+    except EntityAlreadyExists as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+@app.put("/entities/{entity_id}", response_model=CRMEntity, tags=["entities"])
+def upsert_entity(
+    entity_id: str,
+    entity: CRMEntity,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> CRMEntity:
+    if entity.id != entity_id:
+        entity = entity.model_copy(update={"id": entity_id})
+    return repository.upsert_entity(entity)
+
+
+@app.get("/entities", response_model=list[CRMEntity], tags=["entities"])
+def list_entities(
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+    entity_type: Optional[str] = Query(
+        default=None,
+        description="Filter results by CIDOC CRM entity type (e.g. E39_Actor).",
+    ),
+) -> list[CRMEntity]:
+    entity_type_enum: Optional[CRMEntityType] = None
+    if entity_type:
+        try:
+            entity_type_enum = CRMEntityType.from_any(entity_type)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return repository.list_entities(entity_type_enum)
+
+
+@app.get("/entities/{entity_id}", response_model=CRMEntity, tags=["entities"])
+def get_entity(
+    entity_id: str,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> CRMEntity:
+    try:
+        return repository.get_entity(entity_id)
+    except EntityNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@app.delete("/entities/{entity_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["entities"])
+def delete_entity(
+    entity_id: str,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> None:
+    try:
+        repository.delete_entity(entity_id)
+    except EntityNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@app.post(
+    "/relationships",
+    response_model=CRMRelationship,
+    status_code=status.HTTP_201_CREATED,
+    tags=["relationships"],
+)
+def create_relationship(
+    relationship: CRMRelationship,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> CRMRelationship:
+    try:
+        return repository.create_relationship(relationship)
+    except (EntityNotFound, RelationshipAlreadyExists) as exc:
+        status_code = status.HTTP_404_NOT_FOUND if isinstance(exc, EntityNotFound) else status.HTTP_409_CONFLICT
+        raise HTTPException(status_code=status_code, detail=str(exc)) from exc
+
+
+@app.get("/relationships", response_model=list[CRMRelationship], tags=["relationships"])
+def list_relationships(
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+    source_id: Optional[str] = Query(default=None, description="Filter by source entity identifier."),
+    target_id: Optional[str] = Query(default=None, description="Filter by target entity identifier."),
+    property_type: Optional[str] = Query(
+        default=None, description="Filter by CRM property type (e.g. P11_had_participant)."
+    ),
+) -> list[CRMRelationship]:
+    property_type_enum: Optional[CRMPropertyType] = None
+    if property_type:
+        try:
+            property_type_enum = CRMPropertyType.from_any(property_type)
+        except ValueError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return repository.list_relationships(
+        source_id=source_id, target_id=target_id, property_type=property_type_enum
+    )
+
+
+@app.delete("/relationships/{relationship_id}", status_code=status.HTTP_204_NO_CONTENT, tags=["relationships"])
+def delete_relationship(
+    relationship_id: str,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> None:
+    try:
+        repository.delete_relationship(relationship_id)
+    except RelationshipNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+
+@app.get(
+    "/entities/{entity_id}/relationships",
+    response_model=list[CRMRelationship],
+    tags=["entities", "relationships"],
+)
+def get_entity_relationships(
+    entity_id: str,
+    repository: Annotated[GraphRepository, Depends(get_repository)],
+) -> list[CRMRelationship]:
+    try:
+        repository.get_entity(entity_id)
+    except EntityNotFound as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return repository.list_relationships(source_id=entity_id)

--- a/src/cidoc_crm_toolkit/cli.py
+++ b/src/cidoc_crm_toolkit/cli.py
@@ -1,0 +1,179 @@
+"""Command line utilities for the CIDOC CRM toolkit."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+import typer
+
+from .enums import CRMEntityType, CRMPropertyType
+from .models import CRMEntity, CRMIdentifier, CRMRelationship
+from .repository import InMemoryGraphRepository
+
+app = typer.Typer(help="Utilities for working with CIDOC CRM graphs")
+
+
+def _load_repository(store: Optional[Path]) -> InMemoryGraphRepository:
+    repo = InMemoryGraphRepository()
+    if store is None:
+        return repo
+    if store.exists():
+        with store.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        repo.import_data(payload)
+    return repo
+
+
+def _save_repository(repo: InMemoryGraphRepository, store: Optional[Path]) -> None:
+    if store is None:
+        return
+    payload = repo.export_data()
+    with store.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+        handle.write("\n")
+
+
+def _parse_identifiers(values: Iterable[str]) -> list[CRMIdentifier]:
+    identifiers: list[CRMIdentifier] = []
+    for raw in values:
+        if "=" in raw:
+            type_part, value = raw.split("=", 1)
+            identifier_type = type_part.strip() or None
+            identifiers.append(CRMIdentifier(type=identifier_type, value=value.strip()))
+        else:
+            identifiers.append(CRMIdentifier(value=raw.strip()))
+    return identifiers
+
+
+@app.command("entity-add")
+def entity_add(
+    entity_type: str = typer.Argument(..., help="CIDOC CRM class, e.g. E39_Actor"),
+    label: str = typer.Option(..., "--label", help="Primary label for the entity"),
+    description: Optional[str] = typer.Option(None, "--description", help="Optional description"),
+    identifier: Optional[list[str]] = typer.Option(
+        None,
+        "--identifier",
+        help="Identifier definition (value or type=value). Repeatable option.",
+    ),
+    type_tag: Optional[list[str]] = typer.Option(
+        None,
+        "--type-tag",
+        help="Additional rdf:type like information. Repeat option for multiple values.",
+    ),
+    entity_id: Optional[str] = typer.Option(
+        None, "--id", help="Optional custom identifier. Defaults to generated UUID."
+    ),
+    store: Optional[Path] = typer.Option(
+        None, "--store", help="Persist graph state to the given JSON file"
+    ),
+) -> None:
+    repo = _load_repository(store)
+    payload = dict(
+        entity_type=CRMEntityType.from_any(entity_type),
+        label=label,
+        description=description,
+        identifiers=_parse_identifiers(identifier or []),
+        types=list(type_tag or []),
+    )
+    if entity_id:
+        payload["id"] = entity_id
+    entity = CRMEntity(**payload)
+    repo.create_entity(entity)
+    _save_repository(repo, store)
+    typer.echo(json.dumps(entity.model_dump(mode="json"), indent=2))
+
+
+@app.command("entity-list")
+def entity_list(
+    entity_type: Optional[str] = typer.Option(
+        None, "--entity-type", help="Optional filter by CIDOC CRM class"
+    ),
+    store: Optional[Path] = typer.Option(
+        None, "--store", help="Read graph state from the given JSON file"
+    ),
+) -> None:
+    repo = _load_repository(store)
+    entity_type_enum = CRMEntityType.from_any(entity_type) if entity_type else None
+    entities = repo.list_entities(entity_type_enum)
+    typer.echo(json.dumps([entity.model_dump(mode="json") for entity in entities], indent=2))
+
+
+@app.command("relationship-add")
+def relationship_add(
+    property_type: str = typer.Argument(..., help="CIDOC CRM property, e.g. P11_had_participant"),
+    source: str = typer.Option(..., "--source", help="Identifier of the subject entity"),
+    target: str = typer.Option(..., "--target", help="Identifier of the object entity"),
+    description: Optional[str] = typer.Option(None, "--description", help="Optional note"),
+    relationship_id: Optional[str] = typer.Option(None, "--id", help="Optional relationship identifier"),
+    store: Optional[Path] = typer.Option(
+        None, "--store", help="Persist graph state to the given JSON file"
+    ),
+) -> None:
+    repo = _load_repository(store)
+    payload = dict(
+        property_type=CRMPropertyType.from_any(property_type),
+        source_id=source,
+        target_id=target,
+        description=description,
+    )
+    if relationship_id:
+        payload["id"] = relationship_id
+    relationship = CRMRelationship(**payload)
+    repo.create_relationship(relationship)
+    _save_repository(repo, store)
+    typer.echo(json.dumps(relationship.model_dump(mode="json"), indent=2))
+
+
+@app.command("relationship-list")
+def relationship_list(
+    source: Optional[str] = typer.Option(None, "--source", help="Filter by subject entity"),
+    target: Optional[str] = typer.Option(None, "--target", help="Filter by object entity"),
+    property_type: Optional[str] = typer.Option(
+        None, "--property-type", help="Filter by property type"
+    ),
+    store: Optional[Path] = typer.Option(
+        None, "--store", help="Read graph state from the given JSON file"
+    ),
+) -> None:
+    repo = _load_repository(store)
+    property_enum = CRMPropertyType.from_any(property_type) if property_type else None
+    relationships = repo.list_relationships(
+        source_id=source, target_id=target, property_type=property_enum
+    )
+    typer.echo(
+        json.dumps([relationship.model_dump(mode="json") for relationship in relationships], indent=2)
+    )
+
+
+@app.command()
+def export(
+    store: Optional[Path] = typer.Option(
+        None, "--store", help="Read graph state from the given JSON file"
+    ),
+    output: typer.FileTextWrite = typer.Option(sys.stdout, "--output", help="Destination file"),
+) -> None:
+    repo = _load_repository(store)
+    payload = repo.export_data()
+    json.dump(payload, output, indent=2)
+    output.write("\n")
+
+
+@app.command()
+def import_data(
+    store: Optional[Path] = typer.Option(
+        None, "--store", help="Persist imported graph to the given JSON file"
+    ),
+    source: typer.FileText = typer.Option(sys.stdin, "--source", help="Input JSON document"),
+) -> None:
+    payload = json.load(source)
+    repo = InMemoryGraphRepository()
+    repo.import_data(payload)
+    _save_repository(repo, store)
+    typer.echo("Imported graph with " + str(len(payload.get("entities", []))) + " entities")
+
+
+if __name__ == "__main__":
+    app()

--- a/src/cidoc_crm_toolkit/enums.py
+++ b/src/cidoc_crm_toolkit/enums.py
@@ -1,0 +1,45 @@
+"""Enumerations for CIDOC CRM entity and property types."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CRMEntityType(str, Enum):
+    """Subset of CIDOC CRM entity types supported by the toolkit."""
+
+    E2_TEMPORAL_ENTITY = "E2_Temporal_Entity"
+    E5_EVENT = "E5_Event"
+    E39_ACTOR = "E39_Actor"
+    E53_PLACE = "E53_Place"
+    E55_TYPE = "E55_Type"
+    E7_ACTIVITY = "E7_Activity"
+
+    @classmethod
+    def from_any(cls, value: str) -> "CRMEntityType":
+        """Parse a string into a :class:`CRMEntityType` ignoring case and underscores."""
+
+        normalized = value.strip().lower().replace(" ", "_")
+        for member in cls:
+            if member.value.lower() == normalized or member.name.lower() == normalized:
+                return member
+        raise ValueError(f"Unknown CRM entity type: {value}")
+
+
+class CRMPropertyType(str, Enum):
+    """Subset of CIDOC CRM property types supported by the toolkit."""
+
+    P1_IS_IDENTIFIED_BY = "P1_is_identified_by"
+    P7_TOOK_PLACE_AT = "P7_took_place_at"
+    P11_HAD_PARTICIPANT = "P11_had_participant"
+    P14_CARRIED_OUT_BY = "P14_carried_out_by"
+
+    @classmethod
+    def from_any(cls, value: str) -> "CRMPropertyType":
+        """Parse a string into a :class:`CRMPropertyType` ignoring case and underscores."""
+
+        normalized = value.strip().lower().replace(" ", "_")
+        for member in cls:
+            if member.value.lower() == normalized or member.name.lower() == normalized:
+                return member
+        raise ValueError(f"Unknown CRM property type: {value}")

--- a/src/cidoc_crm_toolkit/exceptions.py
+++ b/src/cidoc_crm_toolkit/exceptions.py
@@ -1,0 +1,23 @@
+"""Custom exceptions for the CIDOC CRM toolkit."""
+
+from __future__ import annotations
+
+
+class CRMError(Exception):
+    """Base exception for toolkit errors."""
+
+
+class EntityAlreadyExists(CRMError):
+    """Raised when attempting to create an entity that already exists."""
+
+
+class EntityNotFound(CRMError):
+    """Raised when the requested entity cannot be found."""
+
+
+class RelationshipAlreadyExists(CRMError):
+    """Raised when attempting to add a duplicate relationship."""
+
+
+class RelationshipNotFound(CRMError):
+    """Raised when a relationship could not be located."""

--- a/src/cidoc_crm_toolkit/models.py
+++ b/src/cidoc_crm_toolkit/models.py
@@ -1,0 +1,106 @@
+"""Pydantic models representing CIDOC CRM concepts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from .enums import CRMEntityType, CRMPropertyType
+
+
+class CRMIdentifier(BaseModel):
+    """Identifier associated with a CIDOC CRM entity."""
+
+    type: Optional[str] = Field(
+        default=None,
+        description="Type of identifier, e.g. inventory number or external authority."
+    )
+    value: str = Field(..., description="Identifier value")
+    issued_by: Optional[str] = Field(
+        default=None, description="Authority or institution responsible for the identifier."
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class TimeSpan(BaseModel):
+    """Represents CIDOC CRM E52 Time-Span values for temporal entities."""
+
+    begin_of_begin: Optional[datetime] = Field(
+        default=None, description="Lower bound for the start of the timespan."
+    )
+    end_of_end: Optional[datetime] = Field(
+        default=None, description="Upper bound for the end of the timespan."
+    )
+    label: Optional[str] = Field(default=None, description="Human readable label for the timespan.")
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_range(self) -> "TimeSpan":
+        if self.begin_of_begin and self.end_of_end:
+            if self.begin_of_begin > self.end_of_end:
+                raise ValueError("begin_of_begin must be before end_of_end")
+        return self
+
+
+class CRMEntity(BaseModel):
+    """Base model for CIDOC CRM entities."""
+
+    id: str = Field(
+        default_factory=lambda: str(uuid4()), description="Globally unique identifier for the entity."
+    )
+    entity_type: CRMEntityType = Field(..., description="CIDOC CRM class of the entity.")
+    label: str = Field(..., description="Primary human-readable label for the entity.")
+    description: Optional[str] = Field(default=None, description="Optional descriptive text.")
+    identifiers: List[CRMIdentifier] = Field(
+        default_factory=list, description="Collection of identifiers associated with the entity."
+    )
+    types: List[str] = Field(
+        default_factory=list,
+        description="Additional rdf:type like designations complementing the CRM class.",
+    )
+    time_span: Optional[TimeSpan] = Field(
+        default=None,
+        description="Temporal information relevant to temporal entities (e.g. E5 Event).",
+    )
+    data: Dict[str, object] = Field(
+        default_factory=dict,
+        description="Arbitrary extensible payload to attach domain specific attributes.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("entity_type", mode="before")
+    @classmethod
+    def parse_entity_type(cls, value: str | CRMEntityType) -> CRMEntityType:
+        if isinstance(value, CRMEntityType):
+            return value
+        return CRMEntityType.from_any(str(value))
+
+
+class CRMRelationship(BaseModel):
+    """Model for CIDOC CRM properties connecting two entities."""
+
+    id: str = Field(
+        default_factory=lambda: str(uuid4()), description="Identifier for the relationship edge."
+    )
+    property_type: CRMPropertyType = Field(..., description="CIDOC CRM property type.")
+    source_id: str = Field(..., description="Identifier of the subject entity.")
+    target_id: str = Field(..., description="Identifier of the object entity.")
+    description: Optional[str] = Field(default=None, description="Optional note about the relation.")
+    data: Dict[str, object] = Field(
+        default_factory=dict, description="Extensible property payload for custom applications."
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("property_type", mode="before")
+    @classmethod
+    def parse_property_type(cls, value: str | CRMPropertyType) -> CRMPropertyType:
+        if isinstance(value, CRMPropertyType):
+            return value
+        return CRMPropertyType.from_any(str(value))

--- a/src/cidoc_crm_toolkit/repository.py
+++ b/src/cidoc_crm_toolkit/repository.py
@@ -1,0 +1,207 @@
+"""Graph repository abstractions and in-memory implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Iterable, List, Optional
+
+import networkx as nx
+
+from .enums import CRMEntityType, CRMPropertyType
+from .exceptions import (
+    CRMError,
+    EntityAlreadyExists,
+    EntityNotFound,
+    RelationshipAlreadyExists,
+    RelationshipNotFound,
+)
+from .models import CRMEntity, CRMRelationship
+
+
+class GraphRepository(ABC):
+    """Abstract graph repository for storing CIDOC CRM entities and relationships."""
+
+    @abstractmethod
+    def create_entity(self, entity: CRMEntity) -> CRMEntity:
+        raise NotImplementedError
+
+    @abstractmethod
+    def upsert_entity(self, entity: CRMEntity) -> CRMEntity:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_entity(self, entity_id: str) -> CRMEntity:
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_entity(self, entity_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_entities(self, entity_type: Optional[CRMEntityType] = None) -> List[CRMEntity]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_relationship(self, relationship: CRMRelationship) -> CRMRelationship:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_relationships(
+        self,
+        *,
+        source_id: Optional[str] = None,
+        target_id: Optional[str] = None,
+        property_type: Optional[CRMPropertyType] = None,
+    ) -> List[CRMRelationship]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_relationship(self, relationship_id: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def export_data(self) -> Dict[str, List[Dict[str, object]]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def import_data(self, payload: Dict[str, Iterable[Dict[str, object]]]) -> None:
+        raise NotImplementedError
+
+
+class InMemoryGraphRepository(GraphRepository):
+    """Simple in-memory graph repository backed by NetworkX."""
+
+    def __init__(self) -> None:
+        self._graph = nx.MultiDiGraph()
+
+    # ------------------------------------------------------------------
+    # entity operations
+    # ------------------------------------------------------------------
+    def create_entity(self, entity: CRMEntity) -> CRMEntity:
+        if entity.id in self._graph:
+            raise EntityAlreadyExists(f"Entity {entity.id} already exists")
+        self._graph.add_node(entity.id, entity=entity.model_dump(mode="json"))
+        return entity
+
+    def upsert_entity(self, entity: CRMEntity) -> CRMEntity:
+        self._graph.add_node(entity.id, entity=entity.model_dump(mode="json"))
+        return entity
+
+    def get_entity(self, entity_id: str) -> CRMEntity:
+        try:
+            data = self._graph.nodes[entity_id]["entity"]
+        except KeyError as exc:
+            raise EntityNotFound(f"Entity {entity_id} not found") from exc
+        return CRMEntity.model_validate(data)
+
+    def delete_entity(self, entity_id: str) -> None:
+        if entity_id not in self._graph:
+            raise EntityNotFound(f"Entity {entity_id} not found")
+        self._graph.remove_node(entity_id)
+
+    def list_entities(self, entity_type: Optional[CRMEntityType] = None) -> List[CRMEntity]:
+        results: List[CRMEntity] = []
+        for node_id, attributes in self._graph.nodes(data=True):
+            entity = CRMEntity.model_validate(attributes["entity"])
+            if entity_type and entity.entity_type != entity_type:
+                continue
+            results.append(entity)
+        return sorted(results, key=lambda e: (e.entity_type.value, e.label))
+
+    # ------------------------------------------------------------------
+    # relationship operations
+    # ------------------------------------------------------------------
+    def _relationships_iter(self):
+        for source, target, key, data in self._graph.edges(data=True, keys=True):
+            relationship_dict = data.get("relationship")
+            if not relationship_dict:
+                continue
+            relationship = CRMRelationship.model_validate(relationship_dict)
+            yield source, target, key, relationship
+
+    def _ensure_entity_exists(self, entity_id: str) -> None:
+        if entity_id not in self._graph:
+            raise EntityNotFound(f"Entity {entity_id} not found")
+
+    def create_relationship(self, relationship: CRMRelationship) -> CRMRelationship:
+        self._ensure_entity_exists(relationship.source_id)
+        self._ensure_entity_exists(relationship.target_id)
+
+        for _, _, _, existing in self._relationships_iter():
+            if (
+                existing.id == relationship.id
+                or (
+                    existing.source_id == relationship.source_id
+                    and existing.target_id == relationship.target_id
+                    and existing.property_type == relationship.property_type
+                )
+            ):
+                raise RelationshipAlreadyExists(
+                    "Relationship already exists between the provided entities with the same property."
+                )
+
+        self._graph.add_edge(
+            relationship.source_id,
+            relationship.target_id,
+            key=relationship.id,
+            relationship=relationship.model_dump(mode="json"),
+        )
+        return relationship
+
+    def list_relationships(
+        self,
+        *,
+        source_id: Optional[str] = None,
+        target_id: Optional[str] = None,
+        property_type: Optional[CRMPropertyType] = None,
+    ) -> List[CRMRelationship]:
+        matches: List[CRMRelationship] = []
+        for _, _, _, relationship in self._relationships_iter():
+            if source_id and relationship.source_id != source_id:
+                continue
+            if target_id and relationship.target_id != target_id:
+                continue
+            if property_type and relationship.property_type != property_type:
+                continue
+            matches.append(relationship)
+        return sorted(matches, key=lambda rel: (rel.property_type.value, rel.source_id, rel.target_id))
+
+    def delete_relationship(self, relationship_id: str) -> None:
+        for source, target, key, relationship in self._relationships_iter():
+            if relationship.id == relationship_id:
+                self._graph.remove_edge(source, target, key)
+                return
+        raise RelationshipNotFound(f"Relationship {relationship_id} not found")
+
+    # ------------------------------------------------------------------
+    # serialization helpers
+    # ------------------------------------------------------------------
+    def export_data(self) -> Dict[str, List[Dict[str, object]]]:
+        entities = [
+            CRMEntity.model_validate(attrs["entity"]).model_dump(mode="json")
+            for _, attrs in self._graph.nodes(data=True)
+        ]
+        relationships = [
+            CRMRelationship.model_validate(data["relationship"]).model_dump(mode="json")
+            for _, _, data in self._graph.edges(data=True)
+            if "relationship" in data
+        ]
+        return {"entities": entities, "relationships": relationships}
+
+    def import_data(self, payload: Dict[str, Iterable[Dict[str, object]]]) -> None:
+        self._graph.clear()
+        for entity_payload in payload.get("entities", []) or []:
+            entity = CRMEntity.model_validate(entity_payload)
+            self._graph.add_node(entity.id, entity=entity.model_dump(mode="json"))
+        for relationship_payload in payload.get("relationships", []) or []:
+            relationship = CRMRelationship.model_validate(relationship_payload)
+            if relationship.source_id not in self._graph or relationship.target_id not in self._graph:
+                raise CRMError(
+                    "Relationship references missing entities; ensure entities are imported before relationships."
+                )
+            self._graph.add_edge(
+                relationship.source_id,
+                relationship.target_id,
+                key=relationship.id,
+                relationship=relationship.model_dump(mode="json"),
+            )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,60 @@
+from fastapi.testclient import TestClient
+
+from cidoc_crm_toolkit import api
+from cidoc_crm_toolkit.enums import CRMEntityType, CRMPropertyType
+from cidoc_crm_toolkit.repository import InMemoryGraphRepository
+
+
+def get_client_with_repo():
+    repo = InMemoryGraphRepository()
+
+    def override_repo():
+        return repo
+
+    api.app.dependency_overrides[api.get_repository] = override_repo
+    return TestClient(api.app), repo
+
+
+def test_create_entity_and_relationship_via_api():
+    client, repo = get_client_with_repo()
+
+    response = client.post(
+        "/entities",
+        json={
+            "entity_type": CRMEntityType.E39_ACTOR.value,
+            "label": "Ada Lovelace",
+        },
+    )
+    assert response.status_code == 201
+    actor = response.json()
+
+    response = client.post(
+        "/entities",
+        json={
+            "entity_type": CRMEntityType.E5_EVENT.value,
+            "label": "Analytical Engine Proposal",
+        },
+    )
+    assert response.status_code == 201
+    event = response.json()
+
+    relationship_payload = {
+        "property_type": CRMPropertyType.P11_HAD_PARTICIPANT.value,
+        "source_id": event["id"],
+        "target_id": actor["id"],
+    }
+    response = client.post("/relationships", json=relationship_payload)
+    assert response.status_code == 201
+
+    relationships = client.get("/relationships").json()
+    assert len(relationships) == 1
+    assert relationships[0]["source_id"] == event["id"]
+
+    entity_relationships = client.get(f"/entities/{event['id']}/relationships").json()
+    assert len(entity_relationships) == 1
+
+
+def test_get_missing_entity_returns_404():
+    client, repo = get_client_with_repo()
+    response = client.get("/entities/non-existent")
+    assert response.status_code == 404

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,82 @@
+from cidoc_crm_toolkit.enums import CRMEntityType, CRMPropertyType
+from cidoc_crm_toolkit.exceptions import EntityNotFound, RelationshipAlreadyExists
+from cidoc_crm_toolkit.models import CRMEntity, CRMRelationship
+from cidoc_crm_toolkit.repository import InMemoryGraphRepository
+
+
+def make_entity(entity_type: CRMEntityType, label: str) -> CRMEntity:
+    return CRMEntity(entity_type=entity_type, label=label)
+
+
+def test_create_and_get_entity():
+    repo = InMemoryGraphRepository()
+    entity = make_entity(CRMEntityType.E39_ACTOR, "Ada Lovelace")
+    repo.create_entity(entity)
+
+    retrieved = repo.get_entity(entity.id)
+    assert retrieved.label == "Ada Lovelace"
+    assert retrieved.entity_type == CRMEntityType.E39_ACTOR
+
+    entities = repo.list_entities()
+    assert len(entities) == 1
+
+
+def test_relationship_requires_existing_entities():
+    repo = InMemoryGraphRepository()
+    actor = make_entity(CRMEntityType.E39_ACTOR, "Ada Lovelace")
+    event = make_entity(CRMEntityType.E5_EVENT, "Analytical Engine Proposal")
+    repo.create_entity(actor)
+    repo.create_entity(event)
+
+    relationship = CRMRelationship(
+        property_type=CRMPropertyType.P11_HAD_PARTICIPANT,
+        source_id=event.id,
+        target_id=actor.id,
+    )
+
+    repo.create_relationship(relationship)
+
+    # Duplicate relationship between same nodes with same property is rejected
+    duplicate = CRMRelationship(
+        property_type=CRMPropertyType.P11_HAD_PARTICIPANT,
+        source_id=event.id,
+        target_id=actor.id,
+    )
+    try:
+        repo.create_relationship(duplicate)
+    except RelationshipAlreadyExists:
+        pass
+    else:
+        raise AssertionError("Expected RelationshipAlreadyExists")
+
+
+def test_export_import_roundtrip():
+    repo = InMemoryGraphRepository()
+    actor = make_entity(CRMEntityType.E39_ACTOR, "Ada Lovelace")
+    event = make_entity(CRMEntityType.E5_EVENT, "Analytical Engine Proposal")
+    repo.create_entity(actor)
+    repo.create_entity(event)
+    repo.create_relationship(
+        CRMRelationship(
+            property_type=CRMPropertyType.P11_HAD_PARTICIPANT,
+            source_id=event.id,
+            target_id=actor.id,
+        )
+    )
+
+    payload = repo.export_data()
+
+    other = InMemoryGraphRepository()
+    other.import_data(payload)
+
+    assert len(other.list_entities()) == 2
+    assert other.list_relationships()
+
+    # Removing an entity deletes related relationships implicitly via NetworkX
+    other.delete_entity(actor.id)
+    try:
+        other.get_entity(actor.id)
+    except EntityNotFound:
+        pass
+    else:
+        raise AssertionError("Expected EntityNotFound")


### PR DESCRIPTION
## Summary
- scaffold a Pydantic-based CIDOC CRM toolkit with core models, enums, and domain exceptions
- add an in-memory NetworkX repository, FastAPI JSON API, and Typer CLI following composable tooling practices
- document usage in a README, configure project metadata, and provide repository/API tests for key flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cff65205d4832e9475ae283b82e4b6